### PR TITLE
importando o multer-s3 e adicionando lIbs close #31

### DIFF
--- a/src/config/multer.js
+++ b/src/config/multer.js
@@ -1,6 +1,7 @@
 const multer = require('multer');
 const path = require('path');
 const crypto = require('crypto');
+const multerS3 = require('multer-s3');
 
 module.exports = { 
    dest: path.resolve(__dirname,  "..", "..", "tmp", "uploads"),


### PR DESCRIPTION
Importando o multer-s3 e adicionando a lib AWS-SDK, basicamente toda sdk da amazon toda integração deles a api da aws vai estar composta nessa lib e a gente precisa dela para conseguir fazer a integração com o S3.